### PR TITLE
Kills und Tode im Main Scoreboard hinzugefügt

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,10 @@
             <id>sonatype</id>
             <url>https://oss.sonatype.org/content/groups/public/</url>
         </repository>
+        <repository>
+            <id>jitpack.io</id>
+            <url>https://jitpack.io</url>
+        </repository>
     </repositories>
 
     <dependencies>

--- a/src/main/java/de/Barryonixx/Main/FileManager.java
+++ b/src/main/java/de/Barryonixx/Main/FileManager.java
@@ -12,10 +12,12 @@ public class FileManager {
     public static File cfgFile = new File(folder, "config.yml");
     public static File friendFile = new File(folder, "friends.yml");
     public static File cfgcooldown = new File(folder, "cooldowns.yml");
+    public static File playerDataFile = new File(folder, "playerdata.yml");
 
     public static YamlConfiguration friends;
     public static YamlConfiguration cfg;
     public static YamlConfiguration cfgC;
+    public static YamlConfiguration playerData;
 
     public static void setup(){
         if(!folder.exists()){
@@ -45,6 +47,14 @@ public class FileManager {
             }
         }
 
+        if(!playerDataFile.exists()){
+            try{
+                playerDataFile.createNewFile();
+            }catch(IOException e){
+                e.printStackTrace();
+            }
+        }
+
 
         if(cfgcooldown.exists()){
             System.out.println("Datei gefunden");
@@ -60,6 +70,11 @@ public class FileManager {
             System.out.println("Datei gefunden");
             friends = YamlConfiguration.loadConfiguration(friendFile);
         }
+
+        if(playerDataFile.exists()){
+            System.out.println("Datei gefunden");
+            playerData = YamlConfiguration.loadConfiguration(playerDataFile);
+        }
     }
 
     public static void saveAllFiles(){
@@ -67,6 +82,7 @@ public class FileManager {
           cfg.save(cfgFile);
           friends.save(friendFile);
           cfgC.save(cfgcooldown);
+          playerData.save(playerDataFile);
       }catch (IOException e){
           e.printStackTrace();
       }

--- a/src/main/java/de/Barryonixx/Main/Listeners/ChatListener.java
+++ b/src/main/java/de/Barryonixx/Main/Listeners/ChatListener.java
@@ -169,12 +169,49 @@ public class ChatListener implements Listener {
         player.sendMessage("§7Du wurdest von §c"+killer.getName() + " §7gekillt.");
         killer.sendMessage("§7Du hast §c" + player.getName() + " §7gekillt.");
 
+        YamlConfiguration playerData = FileManager.playerData;
+
+        int kills = 0;
+        int tode = 0;
+
+
+
+        /*
+        * Wenn Tode / Kills nicht gesetzt ist wird 0 als wert übernommen,
+        * ansonsten der Wert der bereits gesetzt ist.
+        * */
+        if(playerData.isSet("Kills." + killer.getName())){
+            kills = playerData.getInt("Kills." + killer.getName());
+        }
+
+        if(playerData.isSet("Tode." + player.getName())){
+            tode = playerData.getInt("Tode." + player.getName());
+        }
+
+        tode++;
+        kills++;
+
+        System.out.println(playerData.isSet("Tode." + player.getName()));
+        System.out.println(tode);
+
+        playerData.set("Kills." + killer.getName(), kills);
+        playerData.set("Tode." + player.getName(), tode);
+
+        FileManager.saveAllFiles();
+
         if(CoinSystem.getEco() == null){
             return;
         }
 
         CoinSystem.getEco().depositPlayer(killer, 25);
         killer.sendMessage("§8» §7Du hast §625 Coins §7erhalten!");
+    }
+
+    @EventHandler
+    public void onRespawn(PlayerRespawnEvent event){
+        Player player = event.getPlayer();
+
+        new MainScoreBoard(player);
     }
 
     @EventHandler

--- a/src/main/java/de/Barryonixx/Main/ScorboardPack/MainScoreBoard.java
+++ b/src/main/java/de/Barryonixx/Main/ScorboardPack/MainScoreBoard.java
@@ -1,9 +1,11 @@
 package de.Barryonixx.Main.ScorboardPack;
 
 import de.Barryonixx.Main.CoinSystem.CoinSystem;
+import de.Barryonixx.Main.FileManager;
 import de.Barryonixx.Main.SkyLydra;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
+import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.entity.Player;
 import org.bukkit.scheduler.BukkitRunnable;
 
@@ -30,22 +32,38 @@ public class MainScoreBoard extends ScoreboardBuilder{
         setScore("§c " + player.getWorld().getName(), 9);
         setScore(ChatColor.DARK_AQUA.toString(), 8);
         setScore("§7 |  §aKills/Tode:", 7);
-        setScore("§e   >>Hier kommen die Tode/Kills", 6);
+        setScore("§e   >>" + getKillsDeathString(player), 6);
         setScore(ChatColor.YELLOW.toString(), 5);
         setScore("§7 |  §aCoins:" , 4);
         setScore("§7   >>" + CoinSystem.getEco().getBalance(player), 3);
         setScore(ChatColor.BLACK.toString(), 2);
         setScore("§7 |  §aUhrzeit: ", 1);
         setScore("§6   >>" + dtf.format(now), 0);
-
-
-
-        //TODO: Kills und TOD
     }
 
     @Override
     public void update() {
 
+    }
+
+    private String getKillsDeathString(Player player){
+        YamlConfiguration playerData = FileManager.playerData;
+
+        String s = "";
+        int kills = 0;
+        int tode = 0;
+
+        if(playerData.isSet("Kills." + player.getName())){
+            kills = playerData.getInt("Kills." + player.getName());
+        }
+
+        if(playerData.isSet("Tode." + player.getName())){
+            tode = playerData.getInt("Tode." + player.getName());
+        }
+
+        s = kills + " | " + tode;
+
+        return s;
     }
 
     private void run(){
@@ -61,7 +79,7 @@ public class MainScoreBoard extends ScoreboardBuilder{
                         setDisplayName("§4§lS§c§lky§7-§4§lL§c§lydra");
 
                         setScore("§7§o        " + player.getWorld().getName(), 9);
-                        setScore("§7   » §e0 | 0", 6);
+                        setScore("§e   >>" + getKillsDeathString(player), 6);
                         setScore("§7   » §e" + CoinSystem.getEco().getBalance(player), 3);
                         setScore("§7   » §e" + dtf.format(now), 0);
                         break;

--- a/src/main/java/de/Barryonixx/Main/SkyLydra.java
+++ b/src/main/java/de/Barryonixx/Main/SkyLydra.java
@@ -55,8 +55,6 @@ public final class SkyLydra extends JavaPlugin {
         Bukkit.getConsoleSender().sendMessage("");
         Bukkit.getConsoleSender().sendMessage(Data.prefix + "Wurde geladen & läuft nun.");
         Bukkit.getConsoleSender().sendMessage("");
-
-
     }
 
     @Override
@@ -65,7 +63,6 @@ public final class SkyLydra extends JavaPlugin {
         Bukkit.getConsoleSender().sendMessage("");
         Bukkit.getConsoleSender().sendMessage(Data.prefix + "Wurde deaktiviert & läuft nun nicht mehr.");
         Bukkit.getConsoleSender().sendMessage("");
-
     }
 
     public static SkyLydra getPlugin() {


### PR DESCRIPTION
Habe eine neue Datei im Filemanager erstellt, in der die ganzen Kills und Tode von Spielern gespeichert werden.
Dafür habe ich im PlayerDeathEvent den Tod des jeweiligen Spielers abgespeichert. Der Scoreboard zeigt nun diese
Zahl an, allerdings musste ich eine neue Instanz vom Mainscoreboard auf den getöteten Spieler erzeugen, da der 
Scoreboard nicht mehr geupdated wurde. Dafür habe ich einfach ein PlayerRespawnEvent erstellt, indem der Spieler das Scoreboard neu gesetzt bekommt.